### PR TITLE
Prevent pass maxHeight prop to main div tag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,6 +195,7 @@ export default class ReactShow extends React.Component {
       transitionProperty,
       unmountOnHide,
       minHeight,
+      maxHeight,
       height,
       transitionOnMount,
       ...rest


### PR DESCRIPTION
Hi, this will remove the console warning about `maxHeight` unknown prop on the div tag tracked in this issue #3 