### PR TITLE
Add repository information

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
   "author": "",
   "homepage": "",
   "license": "MIT",
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/react-tools/react-show.git"
+  },
   "keywords": [
     "react-show",
     "ng-show",


### PR DESCRIPTION
After this change, the repo link is going to be shown in npmjs.com/package/react-show