### PR TITLE
Add a default export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -346,6 +346,8 @@ export class Animate extends React.Component {
   }
 }
 
+module.exports = Animate
+
 // I'll let someone smarter than me figure out how to do this ;)
 
 // export class AnimateGroup extends React.Component {


### PR DESCRIPTION
There is no default export, making `import Show from 'react-show'` or `const Show = require('react-show')` both undefined. This fixes that.